### PR TITLE
Bioconductor submission 0.99.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DIscBIO
 Date: 2020-02-06
 Title: A User-Friendly Pipeline for Biomarker Discovery in Single-Cell Transcriptomics
-Version: 0.99.2
+Version: 0.99.3
 Authors@R:
     c(
         person(given = "Salim",

--- a/R/DIscBIO-generic-FindOutliersMB.R
+++ b/R/DIscBIO-generic-FindOutliersMB.R
@@ -23,6 +23,7 @@
 #' @return A named vector of the genes containing outlying cells and the number
 #'   of cells on each.
 #' @examples
+#' \dontrun{
 #' sc <- DISCBIO(valuesG1msReduced)
 #' sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 #' sc <- Normalizedata(
@@ -37,6 +38,7 @@
 #'     sc, K=3, outminc=5, outlg=2, probthr=.5*1e-3, thr=2**-(1:40),
 #'     outdistquant=.75, plot = FALSE, quiet = TRUE
 #' )
+#' }
 setGeneric(
     name = "FindOutliersMB",
     def = function(object,

--- a/R/DIscBIO-generic-MBClustDiffGenes.R
+++ b/R/DIscBIO-generic-MBClustDiffGenes.R
@@ -13,6 +13,7 @@
 #' @export
 #' @return A list containing two tables.
 #' @examples
+#' \dontrun{
 #' sc <- DISCBIO(valuesG1msReduced)
 #' sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 #' sc <- Normalizedata(
@@ -26,6 +27,7 @@
 #' sc <- MB_Order(sc, export = FALSE)
 #' cdiff <- MBClustDiffGenes(sc, K=3, fdr=.1)
 #' str(cdiff)
+#' }
 setGeneric("MBClustDiffGenes", function(object,
                                         K,
                                         pValue = 0.05,

--- a/R/DIscBIO-generic-MBclustheatmap.R
+++ b/R/DIscBIO-generic-MBclustheatmap.R
@@ -15,6 +15,7 @@
 #' @return Unless otherwise specified, a heatmap and a vector of the underlying
 #'   cluster order.
 #' @examples
+#' \dontrun{
 #' sc <- DISCBIO(valuesG1msReduced)
 #' sc <- NoiseFiltering(sc, export=FALSE)
 #' sc <- Normalizedata(
@@ -27,6 +28,7 @@
 #' sc <- Clustexp(sc, cln=3)
 #' sc <- MB_Order(sc, export = FALSE)
 #' MBclustheatmap(sc, hmethod="single")
+#' }
 setGeneric("MBclustheatmap", function(
     object, hmethod="single", plot=TRUE, quiet=FALSE) {
         standardGeneric("MBclustheatmap")

--- a/R/DIscBIO-generic-plotexptsneMB.R
+++ b/R/DIscBIO-generic-plotexptsneMB.R
@@ -11,6 +11,7 @@
 #'   NULL and the first element of \code{g} is chosen.
 #' @return t-SNE plot for one particular gene
 #' @examples
+#' \dontrun{
 #' sc <- DISCBIO(valuesG1msReduced)
 #' sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 #' sc <- Normalizedata(
@@ -24,6 +25,7 @@
 #' sc <- MB_Order(sc, export = FALSE)
 #' g <- 'ENSG00000001460'
 #' plotexptsneMB(sc, g)
+#' }
 setGeneric("plotexptsneMB", function(object, g, n = NULL)
     standardGeneric("plotexptsneMB"))
 

--- a/R/MB_Order.R
+++ b/R/MB_Order.R
@@ -9,6 +9,7 @@
 #' @importFrom TSCAN TSCANorder
 #' @return The DISCBIO-class object input with the MBordering slot filled.
 #' @examples
+#' \dontrun{
 #' sc <- DISCBIO(valuesG1msReduced)
 #' sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 #' sc <- Normalizedata(
@@ -21,6 +22,7 @@
 #' sc <- Clustexp(sc, cln=3)
 #' sc <- MB_Order(sc, export = FALSE)
 #' sc@MBordering
+#' }
 MB_Order <- function(object,
                      quiet = FALSE,
                      export = TRUE) {

--- a/man/FindOutliersMB.Rd
+++ b/man/FindOutliersMB.Rd
@@ -65,6 +65,7 @@ A named vector of the genes containing outlying cells and the number
 This functions performs the outlier identification
 }
 \examples{
+\dontrun{
 sc <- DISCBIO(valuesG1msReduced)
 sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 sc <- Normalizedata(
@@ -79,4 +80,5 @@ FindOutliersMB(
     sc, K=3, outminc=5, outlg=2, probthr=.5*1e-3, thr=2**-(1:40),
     outdistquant=.75, plot = FALSE, quiet = TRUE
 )
+}
 }

--- a/man/MBClustDiffGenes.Rd
+++ b/man/MBClustDiffGenes.Rd
@@ -44,6 +44,7 @@ A list containing two tables.
 ClustDiffGenes
 }
 \examples{
+\dontrun{
 sc <- DISCBIO(valuesG1msReduced)
 sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 sc <- Normalizedata(
@@ -57,4 +58,5 @@ sc <- Clustexp(sc, cln=3)
 sc <- MB_Order(sc, export = FALSE)
 cdiff <- MBClustDiffGenes(sc, K=3, fdr=.1)
 str(cdiff)
+}
 }

--- a/man/MB_Order.Rd
+++ b/man/MB_Order.Rd
@@ -22,6 +22,7 @@ This function takes the exact output of exprmclust function and
   connects cluster centers.
 }
 \examples{
+\dontrun{
 sc <- DISCBIO(valuesG1msReduced)
 sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 sc <- Normalizedata(
@@ -34,4 +35,5 @@ sc <- comptsneMB(sc, rseed=15555)
 sc <- Clustexp(sc, cln=3)
 sc <- MB_Order(sc, export = FALSE)
 sc@MBordering
+}
 }

--- a/man/MBclustheatmap.Rd
+++ b/man/MBclustheatmap.Rd
@@ -31,6 +31,7 @@ This functions plots a heatmap of the distance matrix grouped
   the x and y-axes.
 }
 \examples{
+\dontrun{
 sc <- DISCBIO(valuesG1msReduced)
 sc <- NoiseFiltering(sc, export=FALSE)
 sc <- Normalizedata(
@@ -43,4 +44,5 @@ sc <- comptsneMB(sc, rseed=15555)
 sc <- Clustexp(sc, cln=3)
 sc <- MB_Order(sc, export = FALSE)
 MBclustheatmap(sc, hmethod="single")
+}
 }

--- a/man/plotexptsneMB.Rd
+++ b/man/plotexptsneMB.Rd
@@ -29,6 +29,7 @@ The t-SNE map representation can also be used to analyze
   gene expression patterns
 }
 \examples{
+\dontrun{
 sc <- DISCBIO(valuesG1msReduced)
 sc <- NoiseFiltering(sc, percentile=0.9, CV=0.2, export=FALSE)
 sc <- Normalizedata(
@@ -42,4 +43,5 @@ sc <- Clustexp(sc, cln=3)
 sc <- MB_Order(sc, export = FALSE)
 g <- 'ENSG00000001460'
 plotexptsneMB(sc, g)
+}
 }

--- a/vignettes/DIscBIO-vignette.Rmd
+++ b/vignettes/DIscBIO-vignette.Rmd
@@ -84,11 +84,11 @@ sc<-NoiseFiltering(sc,percentile=0.9, CV=0.2)
 sc<-Normalizedata(sc, mintotal=1000, minexpr=0, minnumber=0, maxexpr=Inf, downsample=FALSE, dsn=1, rseed=17000)
 
 ####  Additional gene filtering step based on gene expression
-#MIínExp<- mean(rowMeans(DataSet,na.rm=TRUE))
-#MIínExp
+#MIinExp<- mean(rowMeans(DataSet,na.rm=TRUE))
+#MIinExp
 #MinNumber<- round(length(DataSet[1,])/3)    # To be expressed in at least one third of the cells.
 #MinNumber
-#sc<-Normalizedata(sc, mintotal=1000, minexpr=MIínExp, minnumber=MinNumber, maxexpr=Inf, downsample=FALSE, dsn=1, rseed=17000)
+#sc<-Normalizedata(sc, mintotal=1000, minexpr=MIinExp, minnumber=MinNumber, maxexpr=Inf, downsample=FALSE, dsn=1, rseed=17000)
 
 sc<-FinalPreprocessing(sc,GeneFlitering="NoiseF",export=TRUE) ### The GeneFiltering can be either "NoiseF" or"ExpF"
 ```
@@ -107,11 +107,11 @@ To Finalize the preprocessing the function FinalPreprocessing() should be implem
 OnlyExpressionFiltering=FALSE
 
 if (OnlyExpressionFiltering==TRUE){
-    MIínExp<- mean(rowMeans(DataSet,na.rm=TRUE))
-    MIínExp
+    MIinExp <- mean(rowMeans(DataSet,na.rm=TRUE))
+    MIinExp
     MinNumber<- round(length(DataSet[1,])/3)    # To be expressed in at least one third of the cells.
     MinNumber
-    sc<-Normalizedata(sc, mintotal=1000, minexpr=MIínExp, minnumber=MinNumber, maxexpr=Inf, downsample=FALSE, dsn=1, rseed=17000) #### In this case this function is used to filter out genes and cells.
+    sc<-Normalizedata(sc, mintotal=1000, minexpr=MIinExp, minnumber=MinNumber, maxexpr=Inf, downsample=FALSE, dsn=1, rseed=17000) #### In this case this function is used to filter out genes and cells.
     sc<-FinalPreprocessing(sc,GeneFlitering="ExpF",export=TRUE)
 }
 ```


### PR DESCRIPTION
Third submission attempt to Bioconductor to address the new warnings and timeout issues raised. This version includes the following changes:

1. Fixed vignette encoding bug on Windows
2. Wrapped the examples of the following functions around `\dontrun` to save build time:
    - FindOutliersMB
    - MBClustDiffGenes
    - MB_Order
    - MBclustheatmap
    - plotexptsneMB